### PR TITLE
Support for 'See also'

### DIFF
--- a/features/google-translate-default-ui.feature
+++ b/features/google-translate-default-ui.feature
@@ -47,7 +47,7 @@ Feature: Default UI for Google Translate
     Given I set google-translate-default-source-language to "en"
     When I translate "book" to "ru"
     Then I should see translation "книга"
-    
+
   Scenario: Translate a word at point using default target language
     Given I set google-translate-default-source-language to nil
     Given I set google-translate-default-target-language to "ru"
@@ -60,7 +60,7 @@ Feature: Default UI for Google Translate
     Given I set google-translate-default-target-language to "ru"
     When I translate "book" from "en"
     Then I should see translation "книга"
-    
+
   Scenario: Translate a word at point using defaults source and target language
     Given I set google-translate-default-source-language to "en"
     Given I set google-translate-default-target-language to "ru"
@@ -111,20 +111,39 @@ Feature: Default UI for Google Translate
     Given I set google-translate-default-source-language to "en"
     Given I set google-translate-default-target-language to "ru"
     When I translate "sugest"
-    Then I should see suggestion "suggest"
+    Then I should see suggestion "Did you mean: suggest"
+
+  Scenario: Suggestion when related word is translated
+    Given I set google-translate-default-source-language to "en"
+    Given I set google-translate-default-target-language to "vi"
+    When I translate "suggested"
+    Then I should see suggestion "See also: suggest"
 
   Scenario: Linked suggestion: click on suggestion
     Given I set google-translate-default-source-language to "en"
     Given I set google-translate-default-target-language to "ru"
     When I translate "sugest"
-    Then I should see suggestion "suggest"
+    Then I should see suggestion "Did you mean: suggest"
     And I press "TAB"
     And I press "TAB"
     And I press "TAB"
     And I press "RET"
-    Then I should see translation "предлагать"
-    
+    Then I should see translation "предложить"
+
+  Scenario: Linked suggestion: click on suggestion for related word
+    Given I set google-translate-default-source-language to "en"
+    Given I set google-translate-default-target-language to "vi"
+    When I translate "suggested"
+    Then I should see suggestion "See also: suggest"
+    And I press "TAB"
+    And I press "TAB"
+    And I press "TAB"
+    And I press "RET"
+    Then I should see translation "đề xuất"
+
   Scenario: Translate a word emphasized with asterisks like *bold* such as in Org mode
+    Given I set google-translate-default-source-language to "en"
+    Given I set google-translate-default-target-language to "ru"
     Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
     And I go to word "bold"
     When I translate word at point from "en" to "ru"

--- a/features/google-translate-smooth-ui.feature
+++ b/features/google-translate-smooth-ui.feature
@@ -56,19 +56,35 @@ Feature: Smooth UI for Google Translate
   Scenario: Suggestion when word is misspelled
     Given I set google-translate-translation-directions-alist to (("en" . "ru"))
     When I translate "sugest"
-    Then I should see suggestion "suggest"
+    Then I should see suggestion "Did you mean: suggest"
+
+  Scenario: Suggestion when related word is translated
+    Given I set google-translate-translation-directions-alist to (("en" . "vi"))
+    When I translate "suggested"
+    Then I should see suggestion "See also: suggest"
 
   Scenario: Linked suggestion: click on suggestion
     Given I set google-translate-translation-directions-alist to (("en" . "ru"))
     When I translate "sugest"
-    Then I should see suggestion "suggest"
+    Then I should see suggestion "Did you mean: suggest"
     And I press "TAB"
     And I press "TAB"
     And I press "TAB"
     And I press "RET"
     Then I should see translation "предлагать"
 
+  Scenario: Linked suggestion: click on suggestion for related word
+    Given I set google-translate-translation-directions-alist to (("en" . "vi"))
+    When I translate "suggested"
+    Then I should see suggestion "See also: suggest"
+    And I press "TAB"
+    And I press "TAB"
+    And I press "TAB"
+    And I press "RET"
+    Then I should see translation "đề xuất"
+
   Scenario: Translate a word emphasized with asterisks like *bold* such as in Org mode
+    Given I set google-translate-translation-directions-alist to (("en" . "ru"))
     Given I insert "You can make words *bold*, /italic/, _underlined_, =verbatim= and ~code~, and, if you must, ‘+strike-through+’."
     And I go to word "bold"
     When I translate word at point from "en" to "ru"

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -11,11 +11,12 @@
 
 (add-to-list 'load-path google-translate-root-path)
 
-(require 'google-translate)
-(require 'google-translate-default-ui)
-(require 'google-translate-smooth-ui)
-(require 'espuds)
-(require 'ert)
+(let ((load-prefer-newer t))
+  (require 'google-translate)
+  (require 'google-translate-default-ui)
+  (require 'google-translate-smooth-ui)
+  (require 'espuds)
+  (require 'ert))
 
 (Setup
  ;; Before anything has run

--- a/google-translate-core-ui.el
+++ b/google-translate-core-ui.el
@@ -603,23 +603,26 @@ or related translation could be checked as well, e.g: plural nouns."
         (suggestion (gtos-suggestion gtos)))
     (if suggestion
         (with-temp-buffer
-          (insert "\n")
+	  (insert "\n")
           (let ((beg (point)))
-            (insert "Did you mean: ")
+            (insert (car suggestion))
             (facemenu-set-face 'google-translate-suggestion-label-face
                                beg (point)))
           (goto-char (+ (point) 1))
-          (let ((beg (point)))
-            (insert-text-button suggestion
-                                'action 'google-translate--suggestion-action
-                                'follow-link t
-                                'suggestion suggestion
-                                'source-language source-language
-                                'target-language target-language)
-            (facemenu-set-face 'google-translate-suggestion-face
-                               beg (point))
-            (insert "\n"))
-          (buffer-substring (point-min) (point-max)))
+	  (dolist (s (cdr suggestion))
+	    (progn
+	      (insert " ")
+	      (let ((beg (point)))
+		(insert-text-button s
+				    'action 'google-translate--suggestion-action
+				    'follow-link t
+				    'suggestion s
+				    'source-language source-language
+				    'target-language target-language)
+		(facemenu-set-face 'google-translate-suggestion-face
+				   beg (point)))))
+	  (insert "\n")
+	  (buffer-substring (point-min) (point-max)))
       "")))
 
 (defun google-translate--suggestion-action (button)
@@ -697,7 +700,7 @@ message is printed."
                :translation-phonetic (google-translate-json-translation-phonetic json)
                :detailed-translation detailed-translation
                :detailed-definition detailed-definition
-               :suggestion (when (and word-translate-t (null detailed-translation))
+               :suggestion (when word-translate-t
                              (google-translate-json-suggestion json))))
              (output-destination (if (null output-destination)
                                      google-translate-output-destination
@@ -769,8 +772,8 @@ message is printed."
      (google-translate--translation-phonetic gtos " [%s]")
      (if detailed-translation
          (google-translate--detailed-translation
-          detailed-translation "\n%s\n" "%2d. %s\n")
-       (google-translate--suggestion gtos)))))
+          detailed-translation "\n%s\n" "%2d. %s\n") "")
+     (google-translate--suggestion gtos))))
 
 (defun google-translate-buffer-output-translation (gtos)
   "Output translation from GTOS to the temp buffer."
@@ -821,12 +824,12 @@ message is printed."
      (google-translate--translation-phonetic gtos "\n%s\n")
      (if detailed-translation
          (google-translate--detailed-translation
-          detailed-translation "\n%s\n" "%2d. %s\n")
-       (google-translate--suggestion gtos))
+          detailed-translation "\n%s\n" "%2d. %s\n") "")
      (if detailed-definition
          (google-translate--detailed-definition
           detailed-definition "\n%s\n" "%2d. %s\n")
-       ""))))
+       "")
+     (google-translate--suggestion gtos))))
 
 (defun google-translate-read-source-language (&optional prompt)
   "Read a source language, with completion, and return its abbreviation.

--- a/google-translate-core.el
+++ b/google-translate-core.el
@@ -251,9 +251,13 @@ This function does matter when translating misspelled word.  So instead of
 translation it is possible to get suggestion.  It is also useful when
 translating related words, e.g: plural nouns.  In which the suggestion is
 returned in 'See also' section."
-  (let ((info (aref json 7)))
-    (when (and info (> (length info) 0))
-      (aref info 1))))
+  (let ((correction (aref json 7))
+	(related (if (> (length json) 14)
+		     (aref json 14))))
+    (if (and correction (> (length correction) 1))
+	(append (list "Did you mean:") (list (aref correction 1)))
+      (if (and related (> (length related) 0))
+	  (append (list "See also:") (mapcar #'(lambda (x) (aref x 0)) related))))))
 
 (defun google-translate-version ()
   "Query for google translate NG version."

--- a/test/google-translate-core-ui-test.el
+++ b/test/google-translate-core-ui-test.el
@@ -83,13 +83,13 @@
    (string-equal
     "\nDid you mean: suggest\n"
     (google-translate--suggestion (make-gtos
-                                   :suggestion "suggest"
+                                   :suggestion '("Did you mean:" "suggest")
                                    :source-language "en"
                                    :target-language "ru")))))
 
 (ert-deftest test-google-translate--suggestion-action ()
   (with-temp-buffer
-    (let* ((suggestion "suggestion")
+    (let* ((suggestion '("Did you mean:" "suggestion"))
            (source-language "en")
            (target-language "ru")
            (button (insert-text-button "Foo"


### PR DESCRIPTION
- 'See also' is now added to suggestion list if available. This is
  pretty useful when related words are translated. Via this, Google
  Translate provides a suggestion to user for those alternatives
  words as well.
- Add also new TCs and adapt the current suggestion test cases.